### PR TITLE
fix right padding for months with 6 rows. Fixes #1

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -164,7 +164,7 @@ monthDays model =
             weekDay - 1
 
         rightPadding =
-            35 - daysCount - leftPadding
+            (7 - ((daysCount + leftPadding) % 7)) % 7
 
         weeks =
             chunks 7 (List.repeat leftPadding 0 ++ List.range 1 daysCount ++ List.repeat rightPadding 0)


### PR DESCRIPTION
This fixes the rightPadding calculation for months with 6 rows, that is:

* 31 days and 5 or 6 leftPadding (1st of the month on a Saturday or a Sunday)

OR

* 30 days and 6 leftPadding (1st of the month on a Sunday)

For example for October 2017:

```
    October 2017      
Mo Tu We Th Fr Sa Su  
                   1  
 2  3  4  5  6  7  8  
 9 10 11 12 13 14 15  
16 17 18 19 20 21 22  
23 24 25 26 27 28 29  
30 31
```

The current calculation produces `rightPadding` of `-2`, which produces no padding, and hence a misaligned last row. Instead of subtracting from `35`, we need to subtract from the appropriate multiple of 7 in order to avoid negatives.